### PR TITLE
OSOE-536: In NuGet publish workflow, restrict valid versions to vM.N.O or v.M.N.O-alpha.X.[issue-code]

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -7,6 +7,6 @@ on:
 
 jobs:
   publish-nuget:
-    uses: Lombiq/GitHub-Actions/.github/workflows/publish-nuget.yml@dev
+    uses: Lombiq/GitHub-Actions/.github/workflows/publish-nuget.yml@issue/OSOE-536
     secrets:
       API_KEY: ${{ secrets.DEFAULT_NUGET_PUBLISH_API_KEY }}

--- a/Readme.md
+++ b/Readme.md
@@ -109,3 +109,4 @@ The `lint` script calls respective linting scripts for SCSS, JavaScript and Mark
 Bug reports, feature requests, comments, questions, code contributions and love letters are warmly welcome. You can send them to us via GitHub issues and pull requests. Please adhere to our [open-source guidelines](https://lombiq.com/open-source-guidelines) while doing so.
 
 This project is developed by [Lombiq Technologies](https://lombiq.com/). Commercial-grade support is available through Lombiq.
+

--- a/Readme.md
+++ b/Readme.md
@@ -109,4 +109,3 @@ The `lint` script calls respective linting scripts for SCSS, JavaScript and Mark
 Bug reports, feature requests, comments, questions, code contributions and love letters are warmly welcome. You can send them to us via GitHub issues and pull requests. Please adhere to our [open-source guidelines](https://lombiq.com/open-source-guidelines) while doing so.
 
 This project is developed by [Lombiq Technologies](https://lombiq.com/). Commercial-grade support is available through Lombiq.
-


### PR DESCRIPTION
[OSOE-536](https://lombiq.atlassian.net/browse/OSOE-536)

[OSOE-536]: https://lombiq.atlassian.net/browse/OSOE-536?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ