### PR TITLE
OSOE-669: Fixing "Passing percentage units to the global abs() function is deprecated." error

### DIFF
--- a/Lombiq.NodeJs.Extensions/package.json
+++ b/Lombiq.NodeJs.Extensions/package.json
@@ -20,7 +20,7 @@
     "postcss": "^8.4.18",
     "postcss-cli": "^9.1.0",
     "rimraf": "^3.0.2",
-    "sass": "^1.55.0",
+    "sass": "1.59.3",
     "stylelint": "^14.14.0",
     "stylelint-config-standard-scss": "^4.0.0",
     "terser": "^5.15.1",

--- a/Lombiq.NodeJs.Extensions/pnpm-lock.yaml
+++ b/Lombiq.NodeJs.Extensions/pnpm-lock.yaml
@@ -3437,10 +3437,6 @@ packages:
     engines: {node: '>= 4'}
     dev: false
 
-  /immutable/4.1.0:
-    resolution: {integrity: sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ==}
-    dev: false
-
   /import-fresh/3.3.0:
     resolution: {integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==}
     engines: {node: '>=6'}
@@ -5642,16 +5638,6 @@ packages:
     resolution: {integrity: sha512-aJXcif4xnaNUzvUuC5gcb46oTS7zvg4jpMTnuqtrEPlR3vFr4pxtdTwaF1Qs3Enjn9HK+ZlwQui+a7z0SywIzg==}
     dependencies:
       ret: 0.1.15
-    dev: false
-
-  /sass/1.55.0:
-    resolution: {integrity: sha512-Pk+PMy7OGLs9WaxZGJMn7S96dvlyVBwwtToX895WmCpAOr5YiJYEUJfiJidMuKb613z2xNWcXCHEuOvjZbqC6A==}
-    engines: {node: '>=12.0.0'}
-    hasBin: true
-    dependencies:
-      chokidar: 3.5.3
-      immutable: 4.1.0
-      source-map-js: 1.0.2
     dev: false
 
   /select-section/0.4.6:

--- a/Lombiq.NodeJs.Extensions/pnpm-lock.yaml
+++ b/Lombiq.NodeJs.Extensions/pnpm-lock.yaml
@@ -24,7 +24,7 @@ specifiers:
   postcss: ^8.4.18
   postcss-cli: ^9.1.0
   rimraf: ^3.0.2
-  sass: ^1.55.0
+  sass: 1.59.3
   stylelint: ^14.14.0
   stylelint-config-standard-scss: ^4.0.0
   terser: ^5.15.1
@@ -60,7 +60,7 @@ dependencies:
   postcss: 8.4.18
   postcss-cli: 9.1.0_postcss@8.4.18
   rimraf: 3.0.2
-  sass: 1.55.0
+  sass: 1.59.3
   stylelint: 14.14.0
   stylelint-config-standard-scss: 4.0.0_mnalcscwzozovshmobozjae4pq
   terser: 5.15.1


### PR DESCRIPTION
[OSOE-669](https://lombiq.atlassian.net/browse/OSOE-669)

Fixes https://github.com/Lombiq/Orchard-Base-Theme/issues/84.

[OSOE-669]: https://lombiq.atlassian.net/browse/OSOE-669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ