### PR TITLE
OSOE-721: Add the 'no-constant-binary-expression' rule to .eslintrc.lombiq-base.js

### DIFF
--- a/Lombiq.NodeJs.Extensions/config/.eslintrc.lombiq-base.js
+++ b/Lombiq.NodeJs.Extensions/config/.eslintrc.lombiq-base.js
@@ -181,7 +181,9 @@ module.exports = {
 
         'import/no-extraneous-dependencies': 'off',
 
-        'no-warning-comments': 'warn'
+        'no-warning-comments': 'warn',
+
+        'no-constant-binary-expression': 'warn',
     },
 
     // This is required for bleeding edge JS features like optional chaining (@babel/plugin-proposal-optional-chaining).


### PR DESCRIPTION
[OSOE-721](https://lombiq.atlassian.net/browse/OSOE-721)
Fixes #84

[OSOE-721]: https://lombiq.atlassian.net/browse/OSOE-721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ