### PR TITLE
NEST-557: Fix `chalk` version mismatch between package.json and lock files

### DIFF
--- a/Lombiq.NodeJs.Extensions/Docs/Styles.md
+++ b/Lombiq.NodeJs.Extensions/Docs/Styles.md
@@ -5,7 +5,7 @@ This project contains the following pipeline steps for SCSS files:
 - Lint (with [Stylelint](https://stylelint.io/))
 - Prettify (with [Prettier](https://prettier.io/))
 - Compile to CSS
-- Autoprefix
+- Autoprefix<!-- #spell-check-ignore-line -->
 - Minify incl. source map generation
 - Clean output folder
 - Watch for changes and re-run pipeline

--- a/Lombiq.NodeJs.Extensions/Docs/Styles.md
+++ b/Lombiq.NodeJs.Extensions/Docs/Styles.md
@@ -5,7 +5,7 @@ This project contains the following pipeline steps for SCSS files:
 - Lint (with [Stylelint](https://stylelint.io/))
 - Prettify (with [Prettier](https://prettier.io/))
 - Compile to CSS
-- Autoprefix<!-- #spell-check-ignore-line -->
+- Autoprefix
 - Minify incl. source map generation
 - Clean output folder
 - Watch for changes and re-run pipeline

--- a/Lombiq.NodeJs.Extensions/package.json
+++ b/Lombiq.NodeJs.Extensions/package.json
@@ -8,7 +8,7 @@
     "@babel/preset-env": "7.22.10",
     "@textlint-rule/textlint-rule-no-invalid-control-character": "2.0.0",
     "autoprefixer": "10.4.15",
-    "chalk": "5.3.0",
+    "chalk": "4.1.2",
     "clean-css-cli": "5.6.2",
     "copyfiles": "2.4.1",
     "eslint": "8.47.0",


### PR DESCRIPTION
[NEST-557](https://lombiq.atlassian.net/browse/NEST-557)

[NEST-557]: https://lombiq.atlassian.net/browse/NEST-557?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ