### PR TITLE
NEST-596: Exclude third party folders from markdown lint

### DIFF
--- a/Lombiq.NodeJs.Extensions/Docs/Markdown.md
+++ b/Lombiq.NodeJs.Extensions/Docs/Markdown.md
@@ -14,6 +14,9 @@ By default, the markdown pipeline is disabled. You need to provide a valid `sour
 }
 ```
 
+> [!NOTE]
+> Files in some special folders aren't linted. See the current configuration [here](https://github.com/Lombiq/NodeJs-Extensions/blob/dev/Lombiq.NodeJs.Extensions/scripts/lint-markdown.js#L47).
+
 ### Linting the solution directory
 
 You can use the special value `_solution_` as the source to lint every _md_ file in your solution directory. The solution directory is considered to be the first parent directory of your project that contains a _sln_ file.

--- a/Lombiq.NodeJs.Extensions/scripts/lint-markdown.js
+++ b/Lombiq.NodeJs.Extensions/scripts/lint-markdown.js
@@ -44,7 +44,7 @@ function getMarkdownPaths() {
     return findRecursively(
         rootDirectory,
         [/\.md$/i],
-        [/^node_modules$/, /^\.git$/, /^\.vs$/, /^\.vscode$/, /^\.idea$/, /^obj$/, /^bin$/, /^wwwroot$/, /^ThirdParty$/]);
+        [/^node_modules$/, /^\.git$/, /^\.vs$/, /^\.vscode$/, /^\.idea$/, /^obj$/, /^bin$/, /^wwwroot$/, /^ThirdParty$/]); // codespell:ignore
 }
 
 function handleError(error) {

--- a/Lombiq.NodeJs.Extensions/scripts/lint-markdown.js
+++ b/Lombiq.NodeJs.Extensions/scripts/lint-markdown.js
@@ -44,7 +44,7 @@ function getMarkdownPaths() {
     return findRecursively(
         rootDirectory,
         [/\.md$/i],
-        [/^node_modules$/, /^\.git$/, /^\.vs$/, /^\.vscode$/, /^\.idea$/, /^obj$/, /^bin$/, /^wwwroot$/]);
+        [/^node_modules$/, /^\.git$/, /^\.vs$/, /^\.vscode$/, /^\.idea$/, /^obj$/, /^bin$/, /^wwwroot$/, /^ThirdParty$/]);
 }
 
 function handleError(error) {


### PR DESCRIPTION
[NEST-596](https://lombiq.atlassian.net/browse/NEST-596)

[NEST-596]: https://lombiq.atlassian.net/browse/NEST-596?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ