### PR TITLE
NEST-644: Fix pnpm workspace:* error by pinning textlint and copying lockfile

### DIFF
--- a/Lombiq.NodeJs.Extensions/build/Common.props
+++ b/Lombiq.NodeJs.Extensions/build/Common.props
@@ -61,6 +61,7 @@
   <ItemGroup>
     <NodeJsExtensionsNpmPackageFiles Include="$(NodeJsExtensionsInstallationPath)/.npmrc" />
     <NodeJsExtensionsNpmPackageFiles Include="$(NodeJsExtensionsInstallationPath)/package.json" />
+    <NodeJsExtensionsNpmPackageFiles Include="$(NodeJsExtensionsInstallationPath)/pnpm-lock.yaml" />
     <!-- The ** is necessary so that the whole directory is copied over, not just the contained files. -->
     <NodeJsExtensionsNpmPackageFiles Include="$(NodeJsExtensionsInstallationPath)/**/config/**/*.*" />
     <NodeJsExtensionsNpmPackageFiles Include="$(NodeJsExtensionsInstallationPath)/**/scripts/*.*" />

--- a/Lombiq.NodeJs.Extensions/package.json
+++ b/Lombiq.NodeJs.Extensions/package.json
@@ -27,6 +27,7 @@
     "stylelint": "16.25.0",
     "stylelint-config-standard-scss": "16.0.0",
     "terser": "5.44.1",
+    "textlint": "15.2.3",
     "textlint-filter-rule-comments": "1.2.2",
     "textlint-rule-common-misspellings": "1.0.1",
     "textlint-rule-doubled-spaces": "1.0.2",

--- a/Lombiq.NodeJs.Extensions/pnpm-lock.yaml
+++ b/Lombiq.NodeJs.Extensions/pnpm-lock.yaml
@@ -77,6 +77,9 @@ importers:
       terser:
         specifier: 5.44.1
         version: 5.44.1
+      textlint:
+        specifier: 15.2.3
+        version: 15.2.3
       textlint-filter-rule-comments:
         specifier: 1.2.2
         version: 1.2.2(textlint@15.2.3)


### PR DESCRIPTION
[NEST-644](https://lombiq.atlassian.net/browse/NEST-644)
Adding textlint as an explicit production dependency at 15.2.3 instead of relying on auto-install-peers resolution. Also adding pnpm-lock.yaml to the list of files copied to consuming projects so pnpm respects locked versions during 'pnpm install --prod'.

Without these changes, pnpm resolves the latest textlint (15.5.3) as a peer dependency, which uses workspace:* protocol references that fail outside the textlint monorepo: https://github.com/textlint/textlint/issues/1995.